### PR TITLE
Support "date" OpenAPI 3 Data Type from java.time.LocalDate class

### DIFF
--- a/example-external/src/ExampleComplexObjectFromExternal.java
+++ b/example-external/src/ExampleComplexObjectFromExternal.java
@@ -1,16 +1,26 @@
 package de.mcella.openapi.v3.objectconverter.example;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
 public class ExampleComplexObjectFromExternal {
   public final List<Map<String, ExampleFromExternal>> field1;
   public final Map<String, Map<String, List<Map<String, ExampleListOfClassFromExternal>>>> field2;
+  private final List<LocalDate> field3;
+  private final Map<String, LocalDate> field4;
+  public final Map<String, ExampleLocalDateFieldFromExternal> field5;
 
   public ExampleComplexObjectFromExternal(
       List<Map<String, ExampleFromExternal>> field1,
-      Map<String, Map<String, List<Map<String, ExampleListOfClassFromExternal>>>> field2) {
+      Map<String, Map<String, List<Map<String, ExampleListOfClassFromExternal>>>> field2,
+      List<LocalDate> field3,
+      Map<String, LocalDate> field4,
+      Map<String, ExampleLocalDateFieldFromExternal> field5) {
     this.field1 = field1;
     this.field2 = field2;
+    this.field3 = field3;
+    this.field4 = field4;
+    this.field5 = field5;
   }
 }

--- a/example-external/src/ExampleLocalDateFieldFromExternal.java
+++ b/example-external/src/ExampleLocalDateFieldFromExternal.java
@@ -1,0 +1,11 @@
+package de.mcella.openapi.v3.objectconverter.example;
+
+import java.time.LocalDate;
+
+public class ExampleLocalDateFieldFromExternal {
+  public final LocalDate localDateField;
+
+  public ExampleLocalDateFieldFromExternal(LocalDate localDateField) {
+    this.localDateField = localDateField;
+  }
+}

--- a/src/main/java/de/mcella/openapi/v3/objectconverter/datatype/DateField.java
+++ b/src/main/java/de/mcella/openapi/v3/objectconverter/datatype/DateField.java
@@ -1,0 +1,26 @@
+package de.mcella.openapi.v3.objectconverter.datatype;
+
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class DateField implements StandardField {
+
+  @Override
+  public void addField(Field field, Map<String, Object> properties) {
+    addField(field.getName(), properties);
+  }
+
+  @Override
+  public void addField(String fieldName, Map<String, Object> properties) {
+    Map<String, Object> fieldProperties = new LinkedHashMap<>();
+    addType(fieldProperties);
+    properties.put(fieldName, fieldProperties);
+  }
+
+  @Override
+  public void addType(Map<String, Object> properties) {
+    properties.put("type", "string");
+    properties.put("format", "date");
+  }
+}

--- a/src/main/java/de/mcella/openapi/v3/objectconverter/datatype/StandardDataType.java
+++ b/src/main/java/de/mcella/openapi/v3/objectconverter/datatype/StandardDataType.java
@@ -13,7 +13,8 @@ public enum StandardDataType {
   BYTE_WRAPPER("java.lang.Byte"),
   BYTE_PRIMITIVE("byte"),
   BOOLEAN_WRAPPER("java.lang.Boolean"),
-  BOOLEAN_PRIMITIVE("boolean");
+  BOOLEAN_PRIMITIVE("boolean"),
+  LOCAL_DATE("java.time.LocalDate");
 
   private final String typeName;
 

--- a/src/main/java/de/mcella/openapi/v3/objectconverter/datatype/StandardDataType.java
+++ b/src/main/java/de/mcella/openapi/v3/objectconverter/datatype/StandardDataType.java
@@ -1,34 +1,28 @@
 package de.mcella.openapi.v3.objectconverter.datatype;
 
 public enum StandardDataType {
-  STRING("java.lang.String", false),
-  INTEGER_WRAPPER("java.lang.Integer", false),
-  INTEGER_PRIMITIVE("int", true),
-  LONG_WRAPPER("java.lang.Long", false),
-  LONG_PRIMITIVE("long", true),
-  FLOAT_WRAPPER("java.lang.Float", false),
-  FLOAT_PRIMITIVE("float", true),
-  DOUBLE_WRAPPER("java.lang.Double", false),
-  DOUBLE_PRIMITIVE("double", true),
-  BYTE_WRAPPER("java.lang.Byte", false),
-  BYTE_PRIMITIVE("byte", true),
-  BOOLEAN_WRAPPER("java.lang.Boolean", false),
-  BOOLEAN_PRIMITIVE("boolean", true);
+  STRING("java.lang.String"),
+  INTEGER_WRAPPER("java.lang.Integer"),
+  INTEGER_PRIMITIVE("int"),
+  LONG_WRAPPER("java.lang.Long"),
+  LONG_PRIMITIVE("long"),
+  FLOAT_WRAPPER("java.lang.Float"),
+  FLOAT_PRIMITIVE("float"),
+  DOUBLE_WRAPPER("java.lang.Double"),
+  DOUBLE_PRIMITIVE("double"),
+  BYTE_WRAPPER("java.lang.Byte"),
+  BYTE_PRIMITIVE("byte"),
+  BOOLEAN_WRAPPER("java.lang.Boolean"),
+  BOOLEAN_PRIMITIVE("boolean");
 
   private final String typeName;
-  private final boolean primitive;
 
-  StandardDataType(String typeName, boolean primitive) {
+  StandardDataType(String typeName) {
     this.typeName = typeName;
-    this.primitive = primitive;
   }
 
   public String getTypeName() {
     return typeName;
-  }
-
-  public boolean isPrimitive() {
-    return primitive;
   }
 
   public static StandardDataType fromTypeName(String typeName)

--- a/src/main/java/de/mcella/openapi/v3/objectconverter/datatype/StandardDataTypes.java
+++ b/src/main/java/de/mcella/openapi/v3/objectconverter/datatype/StandardDataTypes.java
@@ -17,6 +17,7 @@ public class StandardDataTypes {
     DoubleField doubleField = new DoubleField();
     ByteField byteField = new ByteField();
     BooleanField booleanField = new BooleanField();
+    DateField dateField = new DateField();
     Map<StandardDataType, StandardField> standardDataTypes = new HashMap<>();
     standardDataTypes.put(StandardDataType.STRING, new StringField());
     standardDataTypes.put(StandardDataType.INTEGER_WRAPPER, integerField);
@@ -31,6 +32,7 @@ public class StandardDataTypes {
     standardDataTypes.put(StandardDataType.BYTE_PRIMITIVE, byteField);
     standardDataTypes.put(StandardDataType.BOOLEAN_WRAPPER, booleanField);
     standardDataTypes.put(StandardDataType.BOOLEAN_PRIMITIVE, booleanField);
+    standardDataTypes.put(StandardDataType.LOCAL_DATE, dateField);
     this.standardDataTypes = Collections.unmodifiableMap(standardDataTypes);
   }
 

--- a/src/test/java/de/mcella/openapi/v3/objectconverter/ConverterTest.java
+++ b/src/test/java/de/mcella/openapi/v3/objectconverter/ConverterTest.java
@@ -228,6 +228,17 @@ public class ConverterTest {
   }
 
   @Test
+  public void shouldConvertLocalDate() throws ObjectConverterException, IOException {
+    String className = "java.time.LocalDate";
+
+    Converter.convert(className);
+
+    List<String> expectedSchema =
+        List.of("            schema:", "              type: string", "              format: date");
+    verifyPathsSection(expectedSchema);
+  }
+
+  @Test
   public void shouldConvertClassWithOneStringField() throws ObjectConverterException, IOException {
     String className = "de.mcella.openapi.v3.objectconverter.example.PublicStringField";
 
@@ -329,6 +340,24 @@ public class ConverterTest {
             "              properties:",
             "                field:",
             "                  type: string");
+    verifyPathsSection(expectedSchema);
+  }
+
+  @Test
+  public void shouldConvertClassWithOnePublicLocalDateField()
+      throws ObjectConverterException, IOException {
+    String className = "de.mcella.openapi.v3.objectconverter.example.LocalDateField";
+
+    Converter.convert(className);
+
+    List<String> expectedSchema =
+        List.of(
+            "            schema:",
+            "              type: object",
+            "              properties:",
+            "                field:",
+            "                  type: string",
+            "                  format: date");
     verifyPathsSection(expectedSchema);
   }
 
@@ -576,67 +605,75 @@ public class ConverterTest {
             "                          format: int32");
     verifyPathsSection(expectedSchema);
   }
-  
+
   @Test
   public void shouldConvertListOfString() throws ObjectConverterException, IOException {
-	  String className = "java.util.List<java.lang.String>";
+    String className = "java.util.List<java.lang.String>";
 
-	    Converter.convert(className);
+    Converter.convert(className);
 
-	    List<String> expectedSchema = List.of(
-	    		"            schema:",
-	    		"              type: array",
-	    		"              items:",
-	            "                type: string");
-	    verifyPathsSection(expectedSchema);
+    List<String> expectedSchema =
+        List.of(
+            "            schema:",
+            "              type: array",
+            "              items:",
+            "                type: string");
+    verifyPathsSection(expectedSchema);
   }
-  
+
   @Test
-  public void shouldConvertListOfPublicStringFieldClass() throws ObjectConverterException, IOException {
-	  String className = "java.util.List<de.mcella.openapi.v3.objectconverter.example.PublicStringField>";
+  public void shouldConvertListOfPublicStringFieldClass()
+      throws ObjectConverterException, IOException {
+    String className =
+        "java.util.List<de.mcella.openapi.v3.objectconverter.example.PublicStringField>";
 
-	    Converter.convert(className);
+    Converter.convert(className);
 
-	    List<String> expectedSchema = List.of(
-	    		"            schema:",
-	    		"              type: array",
-	    		"              items:",
-	            "                type: object",
-	    		"                properties:",
-	            "                  field:",
-	            "                    type: string");
-	    verifyPathsSection(expectedSchema);
+    List<String> expectedSchema =
+        List.of(
+            "            schema:",
+            "              type: array",
+            "              items:",
+            "                type: object",
+            "                properties:",
+            "                  field:",
+            "                    type: string");
+    verifyPathsSection(expectedSchema);
   }
-  
+
   @Test
   public void shouldConvertMapOfStringToString() throws ObjectConverterException, IOException {
-	  String className = "java.util.Map<java.lang.String, java.lang.String>";
+    String className = "java.util.Map<java.lang.String, java.lang.String>";
 
-	    Converter.convert(className);
+    Converter.convert(className);
 
-	    List<String> expectedSchema = List.of(
-	    		"            schema:",
-	    		"              type: object",
-	    		"              additionalProperties:",
-	            "                type: string");
-	    verifyPathsSection(expectedSchema);
+    List<String> expectedSchema =
+        List.of(
+            "            schema:",
+            "              type: object",
+            "              additionalProperties:",
+            "                type: string");
+    verifyPathsSection(expectedSchema);
   }
-  
+
   @Test
-  public void shouldConvertMapOfStringToPublicStringFieldClass() throws ObjectConverterException, IOException {
-	  String className = "java.util.Map<java.lang.String, de.mcella.openapi.v3.objectconverter.example.PublicStringField>";
+  public void shouldConvertMapOfStringToPublicStringFieldClass()
+      throws ObjectConverterException, IOException {
+    String className =
+        "java.util.Map<java.lang.String, de.mcella.openapi.v3.objectconverter.example.PublicStringField>";
 
-	    Converter.convert(className);
+    Converter.convert(className);
 
-	    List<String> expectedSchema = List.of(
-	    		"            schema:",
-	    		"              type: object",
-	    		"              additionalProperties:",
-	    		"                type: object",
-	    		"                properties:",
-	            "                  field:",
-	            "                    type: string");
-	    verifyPathsSection(expectedSchema);
+    List<String> expectedSchema =
+        List.of(
+            "            schema:",
+            "              type: object",
+            "              additionalProperties:",
+            "                type: object",
+            "                properties:",
+            "                  field:",
+            "                    type: string");
+    verifyPathsSection(expectedSchema);
   }
 
   private void verifyTemplateSections(

--- a/src/test/java/de/mcella/openapi/v3/objectconverter/datatype/DateFieldTest.java
+++ b/src/test/java/de/mcella/openapi/v3/objectconverter/datatype/DateFieldTest.java
@@ -1,0 +1,78 @@
+package de.mcella.openapi.v3.objectconverter.datatype;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class DateFieldTest {
+
+  private static final String FIELD_NAME = "fieldName";
+
+  private final Field field = mock(Field.class);
+
+  private DateField dateField;
+
+  @Before
+  public void setUp() {
+    this.dateField = new DateField();
+  }
+
+  @Test
+  public void shouldAddDateFieldIntoPropertiesMap() {
+    when(field.getName()).thenReturn(FIELD_NAME);
+    Map<String, Object> properties = new HashMap<>();
+
+    dateField.addField(field, properties);
+
+    assertThat(properties.size(), equalTo(1));
+    assertTrue(properties.containsKey(FIELD_NAME));
+    assertTrue(properties.get(FIELD_NAME) instanceof java.util.Map);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> fieldProperties = (Map<String, Object>) properties.get(FIELD_NAME);
+    assertThat(fieldProperties.size(), equalTo(2));
+    assertTrue(fieldProperties.containsKey("type"));
+    assertThat(fieldProperties.get("type"), equalTo("string"));
+    assertTrue(fieldProperties.containsKey("format"));
+    assertThat(fieldProperties.get("format"), equalTo("date"));
+  }
+
+  @Test
+  public void shouldAddDateFieldFromFieldNameIntoPropertiesMap() {
+    Map<String, Object> properties = new HashMap<>();
+
+    dateField.addField(FIELD_NAME, properties);
+
+    assertThat(properties.size(), equalTo(1));
+    assertTrue(properties.containsKey(FIELD_NAME));
+    assertTrue(properties.get(FIELD_NAME) instanceof java.util.Map);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> fieldProperties = (Map<String, Object>) properties.get(FIELD_NAME);
+    assertThat(fieldProperties.size(), equalTo(2));
+    assertTrue(fieldProperties.containsKey("type"));
+    assertThat(fieldProperties.get("type"), equalTo("string"));
+    assertTrue(fieldProperties.containsKey("format"));
+    assertThat(fieldProperties.get("format"), equalTo("date"));
+  }
+
+  @Test
+  public void shouldAddDateTypeIntoPropertiesMap() {
+    Map<String, Object> properties = new HashMap<>();
+
+    dateField.addType(properties);
+
+    assertThat(properties.size(), equalTo(2));
+    assertTrue(properties.containsKey("type"));
+    assertThat(properties.get("type"), equalTo("string"));
+    assertTrue(properties.containsKey("format"));
+    assertThat(properties.get("format"), equalTo("date"));
+  }
+}

--- a/src/test/java/de/mcella/openapi/v3/objectconverter/datatype/StandardDataTypeTest.java
+++ b/src/test/java/de/mcella/openapi/v3/objectconverter/datatype/StandardDataTypeTest.java
@@ -86,6 +86,12 @@ public class StandardDataTypeTest {
     String typeName = StandardDataType.BOOLEAN_PRIMITIVE.getTypeName();
     assertThat(typeName, equalTo("boolean"));
   }
+  
+  @Test
+  public void shouldGetLocalDateTypeName() {
+    String typeName = StandardDataType.LOCAL_DATE.getTypeName();
+    assertThat(typeName, equalTo("java.time.LocalDate"));
+  }
 
   @Test
   public void shouldGetStringStandardDataTypeFromTypeName()
@@ -177,6 +183,13 @@ public class StandardDataTypeTest {
     StandardDataType standardDataType = StandardDataType.fromTypeName("boolean");
     assertThat(standardDataType, equalTo(StandardDataType.BOOLEAN_PRIMITIVE));
   }
+  
+  @Test
+  public void shouldGetLocalDateStandardDataTypeFromTypeName()
+      throws StandardDataTypeNotFoundException {
+    StandardDataType standardDataType = StandardDataType.fromTypeName("java.time.LocalDate");
+    assertThat(standardDataType, equalTo(StandardDataType.LOCAL_DATE));
+  }
 
   @Test(expected = StandardDataTypeNotFoundException.class)
   public void shouldThrowStandardDataTypeNotFoundExceptionOnGetStandardDataTypeFromUnknownTypeName()
@@ -247,6 +260,11 @@ public class StandardDataTypeTest {
   @Test
   public void shouldBooleanPrimitiveTypeNameBeAStandardDataType() {
     assertTrue(StandardDataType.isStandardDataType("boolean"));
+  }
+  
+  @Test
+  public void shouldLocalDateTypeNameBeAStandardDataType() {
+    assertTrue(StandardDataType.isStandardDataType("java.time.LocalDate"));
   }
 
   @Test

--- a/src/test/java/de/mcella/openapi/v3/objectconverter/datatype/StandardDataTypeTest.java
+++ b/src/test/java/de/mcella/openapi/v3/objectconverter/datatype/StandardDataTypeTest.java
@@ -16,19 +16,9 @@ public class StandardDataTypeTest {
   }
 
   @Test
-  public void shouldStringDataTypeNotBePrimitive() {
-    assertFalse(StandardDataType.STRING.isPrimitive());
-  }
-
-  @Test
   public void shouldGetIntegerWrapperTypeName() {
     String typeName = StandardDataType.INTEGER_WRAPPER.getTypeName();
     assertThat(typeName, equalTo("java.lang.Integer"));
-  }
-
-  @Test
-  public void shouldIntegerWrapperDataTypeNotBePrimitive() {
-    assertFalse(StandardDataType.INTEGER_WRAPPER.isPrimitive());
   }
 
   @Test
@@ -38,19 +28,9 @@ public class StandardDataTypeTest {
   }
 
   @Test
-  public void shouldIntegerPrimitiveDataTypeBePrimitive() {
-    assertTrue(StandardDataType.INTEGER_PRIMITIVE.isPrimitive());
-  }
-
-  @Test
   public void shouldGetLongWrapperTypeName() {
     String typeName = StandardDataType.LONG_WRAPPER.getTypeName();
     assertThat(typeName, equalTo("java.lang.Long"));
-  }
-
-  @Test
-  public void shouldLongWrapperDataTypeNotBePrimitive() {
-    assertFalse(StandardDataType.LONG_WRAPPER.isPrimitive());
   }
 
   @Test
@@ -60,19 +40,9 @@ public class StandardDataTypeTest {
   }
 
   @Test
-  public void shouldLongPrimitiveDataTypeBePrimitive() {
-    assertTrue(StandardDataType.LONG_PRIMITIVE.isPrimitive());
-  }
-
-  @Test
   public void shouldGetFloatWrapperTypeName() {
     String typeName = StandardDataType.FLOAT_WRAPPER.getTypeName();
     assertThat(typeName, equalTo("java.lang.Float"));
-  }
-
-  @Test
-  public void shouldFloatWrapperDataTypeNotBePrimitive() {
-    assertFalse(StandardDataType.FLOAT_WRAPPER.isPrimitive());
   }
 
   @Test
@@ -82,19 +52,9 @@ public class StandardDataTypeTest {
   }
 
   @Test
-  public void shouldFloatPrimitiveDataTypeBePrimitive() {
-    assertTrue(StandardDataType.FLOAT_PRIMITIVE.isPrimitive());
-  }
-
-  @Test
   public void shouldGetDoubleWrapperTypeName() {
     String typeName = StandardDataType.DOUBLE_WRAPPER.getTypeName();
     assertThat(typeName, equalTo("java.lang.Double"));
-  }
-
-  @Test
-  public void shouldDoubleWrapperDataTypeNotBePrimitive() {
-    assertFalse(StandardDataType.DOUBLE_WRAPPER.isPrimitive());
   }
 
   @Test
@@ -104,19 +64,9 @@ public class StandardDataTypeTest {
   }
 
   @Test
-  public void shouldDoublePrimitiveDataTypeBePrimitive() {
-    assertTrue(StandardDataType.DOUBLE_PRIMITIVE.isPrimitive());
-  }
-
-  @Test
   public void shouldGetByteWrapperTypeName() {
     String typeName = StandardDataType.BYTE_WRAPPER.getTypeName();
     assertThat(typeName, equalTo("java.lang.Byte"));
-  }
-
-  @Test
-  public void shouldByteWrapperDataTypeNotBePrimitive() {
-    assertFalse(StandardDataType.BYTE_WRAPPER.isPrimitive());
   }
 
   @Test
@@ -126,30 +76,15 @@ public class StandardDataTypeTest {
   }
 
   @Test
-  public void shouldBytePrimitiveDataTypeBePrimitive() {
-    assertTrue(StandardDataType.BYTE_PRIMITIVE.isPrimitive());
-  }
-
-  @Test
   public void shouldGetBooleanWrapperTypeName() {
     String typeName = StandardDataType.BOOLEAN_WRAPPER.getTypeName();
     assertThat(typeName, equalTo("java.lang.Boolean"));
   }
 
   @Test
-  public void shouldBooleanWrapperDataTypeNotBePrimitive() {
-    assertFalse(StandardDataType.BYTE_WRAPPER.isPrimitive());
-  }
-
-  @Test
   public void shouldGetBooleanPrimitiveTypeName() {
     String typeName = StandardDataType.BOOLEAN_PRIMITIVE.getTypeName();
     assertThat(typeName, equalTo("boolean"));
-  }
-
-  @Test
-  public void shouldBooleanPrimitiveDataTypeBePrimitive() {
-    assertTrue(StandardDataType.BOOLEAN_PRIMITIVE.isPrimitive());
   }
 
   @Test

--- a/src/test/java/de/mcella/openapi/v3/objectconverter/datatype/StandardDataTypesTest.java
+++ b/src/test/java/de/mcella/openapi/v3/objectconverter/datatype/StandardDataTypesTest.java
@@ -93,6 +93,12 @@ public class StandardDataTypesTest {
     StandardField standardField = standardDataTypes.getStandardField("boolean");
     assertTrue(standardField instanceof BooleanField);
   }
+  
+  @Test
+  public void shouldGetStandardFieldFromLocalDateTypeName() throws ObjectConverterException {
+    StandardField standardField = standardDataTypes.getStandardField("java.time.LocalDate");
+    assertTrue(standardField instanceof DateField);
+  }
 
   @Test(expected = ObjectConverterException.class)
   public void shouldThrowObjectConverterExceptionOnGetStandardFieldFromUnknownTypeName()

--- a/src/test/java/de/mcella/openapi/v3/objectconverter/example/LocalDateField.java
+++ b/src/test/java/de/mcella/openapi/v3/objectconverter/example/LocalDateField.java
@@ -1,0 +1,11 @@
+package de.mcella.openapi.v3.objectconverter.example;
+
+import java.time.LocalDate;
+
+public class LocalDateField {
+	public final LocalDate field;
+	
+	public LocalDateField(LocalDate field) {
+		this.field = field;
+	}
+}


### PR DESCRIPTION
Add support for "date" OpenAPI 3 Data Type.
The supported Java class is "java.time.LocalDate".
The "java.time.LocalDate" class is supported as Custom Class field, as List generic class, and as Map Generic value class.
Resolves #1 