### PR TITLE
Support "dateTime" OpenAPI 3 Data Type from java.time.OffsetDateTime class

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ The supported OpenAPI 3 data types are the following:
 | string | string | | |
 | byte | string | byte | base64 encoded characters |
 | boolean | boolean | | |
+| date | string | date | As defined by full-date - [RFC3339](https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14) |
+| dateTime | string | date-time | As defined by date-time - [RFC3339](https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14) |
 
 The application supports both Java primitive types and Java wrapper classes.
 

--- a/example-external/src/ExampleComplexObjectFromExternal.java
+++ b/example-external/src/ExampleComplexObjectFromExternal.java
@@ -1,6 +1,7 @@
 package de.mcella.openapi.v3.objectconverter.example;
 
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -10,17 +11,26 @@ public class ExampleComplexObjectFromExternal {
   private final List<LocalDate> field3;
   private final Map<String, LocalDate> field4;
   public final Map<String, ExampleLocalDateFieldFromExternal> field5;
+  private final List<OffsetDateTime> field6;
+  private final Map<String, OffsetDateTime> field7;
+  public final Map<String, ExampleOffsetDateTimeFieldFromExternal> field8;
 
   public ExampleComplexObjectFromExternal(
       List<Map<String, ExampleFromExternal>> field1,
       Map<String, Map<String, List<Map<String, ExampleListOfClassFromExternal>>>> field2,
       List<LocalDate> field3,
       Map<String, LocalDate> field4,
-      Map<String, ExampleLocalDateFieldFromExternal> field5) {
+      Map<String, ExampleLocalDateFieldFromExternal> field5,
+      List<OffsetDateTime> field6,
+      Map<String, OffsetDateTime> field7,
+      Map<String, ExampleOffsetDateTimeFieldFromExternal> field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;
     this.field4 = field4;
     this.field5 = field5;
+    this.field6 = field6;
+    this.field7 = field7;
+    this.field8 = field8;
   }
 }

--- a/example-external/src/ExampleOffsetDateTimeFieldFromExternal.java
+++ b/example-external/src/ExampleOffsetDateTimeFieldFromExternal.java
@@ -1,0 +1,11 @@
+package de.mcella.openapi.v3.objectconverter.example;
+
+import java.time.OffsetDateTime;
+
+public class ExampleOffsetDateTimeFieldFromExternal {
+  public final OffsetDateTime offsetDateTimeField;
+
+  public ExampleOffsetDateTimeFieldFromExternal(OffsetDateTime offsetDateTimeField) {
+    this.offsetDateTimeField = offsetDateTimeField;
+  }
+}

--- a/src/main/java/de/mcella/openapi/v3/objectconverter/datatype/DateTimeField.java
+++ b/src/main/java/de/mcella/openapi/v3/objectconverter/datatype/DateTimeField.java
@@ -1,0 +1,26 @@
+package de.mcella.openapi.v3.objectconverter.datatype;
+
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class DateTimeField implements StandardField {
+
+  @Override
+  public void addField(Field field, Map<String, Object> properties) {
+    addField(field.getName(), properties);
+  }
+
+  @Override
+  public void addField(String fieldName, Map<String, Object> properties) {
+    Map<String, Object> fieldProperties = new LinkedHashMap<>();
+    addType(fieldProperties);
+    properties.put(fieldName, fieldProperties);
+  }
+
+  @Override
+  public void addType(Map<String, Object> properties) {
+    properties.put("type", "string");
+    properties.put("format", "date-time");
+  }
+}

--- a/src/main/java/de/mcella/openapi/v3/objectconverter/datatype/StandardDataType.java
+++ b/src/main/java/de/mcella/openapi/v3/objectconverter/datatype/StandardDataType.java
@@ -14,7 +14,8 @@ public enum StandardDataType {
   BYTE_PRIMITIVE("byte"),
   BOOLEAN_WRAPPER("java.lang.Boolean"),
   BOOLEAN_PRIMITIVE("boolean"),
-  LOCAL_DATE("java.time.LocalDate");
+  LOCAL_DATE("java.time.LocalDate"),
+  OFFSET_DATE_TIME("java.time.OffsetDateTime");
 
   private final String typeName;
 

--- a/src/main/java/de/mcella/openapi/v3/objectconverter/datatype/StandardDataTypes.java
+++ b/src/main/java/de/mcella/openapi/v3/objectconverter/datatype/StandardDataTypes.java
@@ -18,6 +18,7 @@ public class StandardDataTypes {
     ByteField byteField = new ByteField();
     BooleanField booleanField = new BooleanField();
     DateField dateField = new DateField();
+    DateTimeField dateTimeField = new DateTimeField();
     Map<StandardDataType, StandardField> standardDataTypes = new HashMap<>();
     standardDataTypes.put(StandardDataType.STRING, new StringField());
     standardDataTypes.put(StandardDataType.INTEGER_WRAPPER, integerField);
@@ -33,6 +34,7 @@ public class StandardDataTypes {
     standardDataTypes.put(StandardDataType.BOOLEAN_WRAPPER, booleanField);
     standardDataTypes.put(StandardDataType.BOOLEAN_PRIMITIVE, booleanField);
     standardDataTypes.put(StandardDataType.LOCAL_DATE, dateField);
+    standardDataTypes.put(StandardDataType.OFFSET_DATE_TIME, dateTimeField);
     this.standardDataTypes = Collections.unmodifiableMap(standardDataTypes);
   }
 

--- a/src/test/java/de/mcella/openapi/v3/objectconverter/ConverterTest.java
+++ b/src/test/java/de/mcella/openapi/v3/objectconverter/ConverterTest.java
@@ -239,6 +239,18 @@ public class ConverterTest {
   }
 
   @Test
+  public void shouldConvertOffsetDateTime() throws ObjectConverterException, IOException {
+    String className = "java.time.OffsetDateTime";
+
+    Converter.convert(className);
+
+    List<String> expectedSchema =
+        List.of(
+            "            schema:", "              type: string", "              format: date-time");
+    verifyPathsSection(expectedSchema);
+  }
+
+  @Test
   public void shouldConvertClassWithOneStringField() throws ObjectConverterException, IOException {
     String className = "de.mcella.openapi.v3.objectconverter.example.PublicStringField";
 
@@ -358,6 +370,24 @@ public class ConverterTest {
             "                field:",
             "                  type: string",
             "                  format: date");
+    verifyPathsSection(expectedSchema);
+  }
+
+  @Test
+  public void shouldConvertClassWithOnePublicOffsetDateTimeField()
+      throws ObjectConverterException, IOException {
+    String className = "de.mcella.openapi.v3.objectconverter.example.OffsetDateTimeField";
+
+    Converter.convert(className);
+
+    List<String> expectedSchema =
+        List.of(
+            "            schema:",
+            "              type: object",
+            "              properties:",
+            "                field:",
+            "                  type: string",
+            "                  format: date-time");
     verifyPathsSection(expectedSchema);
   }
 

--- a/src/test/java/de/mcella/openapi/v3/objectconverter/datatype/DateTimeFieldTest.java
+++ b/src/test/java/de/mcella/openapi/v3/objectconverter/datatype/DateTimeFieldTest.java
@@ -1,0 +1,78 @@
+package de.mcella.openapi.v3.objectconverter.datatype;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class DateTimeFieldTest {
+
+  private static final String FIELD_NAME = "fieldName";
+
+  private final Field field = mock(Field.class);
+
+  private DateTimeField dateTimeField;
+
+  @Before
+  public void setUp() {
+    this.dateTimeField = new DateTimeField();
+  }
+
+  @Test
+  public void shouldAddDateTimeFieldIntoPropertiesMap() {
+    when(field.getName()).thenReturn(FIELD_NAME);
+    Map<String, Object> properties = new HashMap<>();
+
+    dateTimeField.addField(field, properties);
+
+    assertThat(properties.size(), equalTo(1));
+    assertTrue(properties.containsKey(FIELD_NAME));
+    assertTrue(properties.get(FIELD_NAME) instanceof java.util.Map);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> fieldProperties = (Map<String, Object>) properties.get(FIELD_NAME);
+    assertThat(fieldProperties.size(), equalTo(2));
+    assertTrue(fieldProperties.containsKey("type"));
+    assertThat(fieldProperties.get("type"), equalTo("string"));
+    assertTrue(fieldProperties.containsKey("format"));
+    assertThat(fieldProperties.get("format"), equalTo("date-time"));
+  }
+
+  @Test
+  public void shouldAddDateTimeFieldFromFieldNameIntoPropertiesMap() {
+    Map<String, Object> properties = new HashMap<>();
+
+    dateTimeField.addField(FIELD_NAME, properties);
+
+    assertThat(properties.size(), equalTo(1));
+    assertTrue(properties.containsKey(FIELD_NAME));
+    assertTrue(properties.get(FIELD_NAME) instanceof java.util.Map);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> fieldProperties = (Map<String, Object>) properties.get(FIELD_NAME);
+    assertThat(fieldProperties.size(), equalTo(2));
+    assertTrue(fieldProperties.containsKey("type"));
+    assertThat(fieldProperties.get("type"), equalTo("string"));
+    assertTrue(fieldProperties.containsKey("format"));
+    assertThat(fieldProperties.get("format"), equalTo("date-time"));
+  }
+
+  @Test
+  public void shouldAddDateTimeTypeIntoPropertiesMap() {
+    Map<String, Object> properties = new HashMap<>();
+
+    dateTimeField.addType(properties);
+
+    assertThat(properties.size(), equalTo(2));
+    assertTrue(properties.containsKey("type"));
+    assertThat(properties.get("type"), equalTo("string"));
+    assertTrue(properties.containsKey("format"));
+    assertThat(properties.get("format"), equalTo("date-time"));
+  }
+}

--- a/src/test/java/de/mcella/openapi/v3/objectconverter/datatype/StandardDataTypeTest.java
+++ b/src/test/java/de/mcella/openapi/v3/objectconverter/datatype/StandardDataTypeTest.java
@@ -86,11 +86,17 @@ public class StandardDataTypeTest {
     String typeName = StandardDataType.BOOLEAN_PRIMITIVE.getTypeName();
     assertThat(typeName, equalTo("boolean"));
   }
-  
+
   @Test
   public void shouldGetLocalDateTypeName() {
     String typeName = StandardDataType.LOCAL_DATE.getTypeName();
     assertThat(typeName, equalTo("java.time.LocalDate"));
+  }
+
+  @Test
+  public void shouldGetOffsetDateTimeTypeName() {
+    String typeName = StandardDataType.OFFSET_DATE_TIME.getTypeName();
+    assertThat(typeName, equalTo("java.time.OffsetDateTime"));
   }
 
   @Test
@@ -183,12 +189,19 @@ public class StandardDataTypeTest {
     StandardDataType standardDataType = StandardDataType.fromTypeName("boolean");
     assertThat(standardDataType, equalTo(StandardDataType.BOOLEAN_PRIMITIVE));
   }
-  
+
   @Test
   public void shouldGetLocalDateStandardDataTypeFromTypeName()
       throws StandardDataTypeNotFoundException {
     StandardDataType standardDataType = StandardDataType.fromTypeName("java.time.LocalDate");
     assertThat(standardDataType, equalTo(StandardDataType.LOCAL_DATE));
+  }
+
+  @Test
+  public void shouldGetOffsetDateTimeStandardDataTypeFromTypeName()
+      throws StandardDataTypeNotFoundException {
+    StandardDataType standardDataType = StandardDataType.fromTypeName("java.time.OffsetDateTime");
+    assertThat(standardDataType, equalTo(StandardDataType.OFFSET_DATE_TIME));
   }
 
   @Test(expected = StandardDataTypeNotFoundException.class)
@@ -261,10 +274,15 @@ public class StandardDataTypeTest {
   public void shouldBooleanPrimitiveTypeNameBeAStandardDataType() {
     assertTrue(StandardDataType.isStandardDataType("boolean"));
   }
-  
+
   @Test
   public void shouldLocalDateTypeNameBeAStandardDataType() {
     assertTrue(StandardDataType.isStandardDataType("java.time.LocalDate"));
+  }
+
+  @Test
+  public void shouldOffsetDateTimeTypeNameBeAStandardDataType() {
+    assertTrue(StandardDataType.isStandardDataType("java.time.OffsetDateTime"));
   }
 
   @Test

--- a/src/test/java/de/mcella/openapi/v3/objectconverter/datatype/StandardDataTypesTest.java
+++ b/src/test/java/de/mcella/openapi/v3/objectconverter/datatype/StandardDataTypesTest.java
@@ -93,11 +93,17 @@ public class StandardDataTypesTest {
     StandardField standardField = standardDataTypes.getStandardField("boolean");
     assertTrue(standardField instanceof BooleanField);
   }
-  
+
   @Test
   public void shouldGetStandardFieldFromLocalDateTypeName() throws ObjectConverterException {
     StandardField standardField = standardDataTypes.getStandardField("java.time.LocalDate");
     assertTrue(standardField instanceof DateField);
+  }
+
+  @Test
+  public void shouldGetStandardFieldFromOffsetDateTimeTypeName() throws ObjectConverterException {
+    StandardField standardField = standardDataTypes.getStandardField("java.time.OffsetDateTime");
+    assertTrue(standardField instanceof DateTimeField);
   }
 
   @Test(expected = ObjectConverterException.class)

--- a/src/test/java/de/mcella/openapi/v3/objectconverter/example/OffsetDateTimeField.java
+++ b/src/test/java/de/mcella/openapi/v3/objectconverter/example/OffsetDateTimeField.java
@@ -1,0 +1,11 @@
+package de.mcella.openapi.v3.objectconverter.example;
+
+import java.time.OffsetDateTime;
+
+public class OffsetDateTimeField {
+  public final OffsetDateTime field;
+
+  public OffsetDateTimeField(OffsetDateTime field) {
+    this.field = field;
+  }
+}


### PR DESCRIPTION
Add support for "dateTime" OpenAPI 3 Data Type.
The supported Java class is "java.time.OffsetDateTime".
The "java.time.OffsetDateTime" class is supported as Custom Class field, as List generic class, and as Map Generic value class.
Resolves #3 